### PR TITLE
fix: avoid crypto.randomUUID crashes in dev

### DIFF
--- a/packages/api/src/do/connection-do.ts
+++ b/packages/api/src/do/connection-do.ts
@@ -1,6 +1,7 @@
 import type { Env } from "../env.js";
 import { verifyToken, getJwtSecret } from "../utils/auth.js";
 import { generateId as generateIdUtil } from "../utils/id.js";
+import { randomUUID } from "../utils/uuid.js";
 
 /**
  * ConnectionDO — one Durable Object instance per BotsChat user.
@@ -150,7 +151,7 @@ export class ConnectionDO implements DurableObject {
     }
 
     const url = new URL(request.url);
-    const sessionId = url.pathname.split("/client/")[1] || crypto.randomUUID();
+    const sessionId = url.pathname.split("/client/")[1] || randomUUID();
 
     const pair = new WebSocketPair();
     const [client, server] = [pair[0], pair[1]];
@@ -607,7 +608,7 @@ export class ConnectionDO implements DurableObject {
         "image/webp": "webp",
       };
       const ext = extMap[contentType] ?? "png";
-      const key = `media/${userId}/${Date.now()}-${crypto.randomUUID().slice(0, 8)}.${ext}`;
+      const key = `media/${userId}/${Date.now()}-${randomUUID().slice(0, 8)}.${ext}`;
 
       // Upload to R2
       await this.env.MEDIA.put(key, body, {
@@ -636,7 +637,7 @@ export class ConnectionDO implements DurableObject {
   }): Promise<void> {
     try {
       const userId = (await this.state.storage.get<string>("userId")) ?? "unknown";
-      const id = opts.id ?? crypto.randomUUID();
+      const id = opts.id ?? randomUUID();
 
       // Extract threadId from sessionKey pattern: ....:thread:{threadId}
       let threadId = opts.threadId;

--- a/packages/api/src/routes/upload.ts
+++ b/packages/api/src/routes/upload.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import type { Env } from "../env.js";
 import { signMediaUrl, getJwtSecret } from "../utils/auth.js";
+import { randomUUID } from "../utils/uuid.js";
 
 export const upload = new Hono<{
   Bindings: Env;
@@ -38,7 +39,7 @@ upload.post("/", async (c) => {
   const ext = file.name.split(".").pop()?.toLowerCase() ?? "png";
   // SVG is excluded — it can contain <script> tags and is a known XSS vector
   const safeExt = ["jpg", "jpeg", "png", "gif", "webp", "bmp", "ico"].includes(ext) ? ext : "png";
-  const filename = `${Date.now()}-${crypto.randomUUID().slice(0, 8)}.${safeExt}`;
+  const filename = `${Date.now()}-${randomUUID().slice(0, 8)}.${safeExt}`;
   const key = `media/${userId}/${filename}`;
 
   // Upload to R2

--- a/packages/api/src/utils/uuid.ts
+++ b/packages/api/src/utils/uuid.ts
@@ -1,0 +1,17 @@
+export function randomUUID(): string {
+  if (typeof crypto !== "undefined" && typeof (crypto as Crypto).randomUUID === "function") {
+    return (crypto as Crypto).randomUUID();
+  }
+
+  const bytes = new Uint8Array(16);
+  if (typeof crypto !== "undefined" && typeof (crypto as Crypto).getRandomValues === "function") {
+    (crypto as Crypto).getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < 16; i++) bytes[i] = Math.floor(Math.random() * 256);
+  }
+
+  bytes[6] = (bytes[6]! & 0x0f) | 0x40;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -28,6 +28,7 @@ import { useIsMobile } from "./hooks/useIsMobile";
 import { MobileLayout } from "./components/MobileLayout";
 import { dlog } from "./debug-log";
 import { gtagPageView } from "./analytics";
+import { randomUUID } from "./utils/uuid";
 
 export default function App() {
   const [state, dispatch] = useReducer(appReducer, initialState, (init): AppState => {
@@ -483,7 +484,7 @@ export default function App() {
           // from the server when the user navigates to that session.
           if (!isCurrentSession(sessionKey)) break;
           const chatMsg: ChatMessage = {
-            id: crypto.randomUUID(),
+            id: randomUUID(),
             sender: "agent",
             text: msg.text as string,
             timestamp: Date.now(),
@@ -500,7 +501,7 @@ export default function App() {
         case "agent.media": {
           if (!isCurrentSession(sessionKey)) break;
           const mediaMsg: ChatMessage = {
-            id: crypto.randomUUID(),
+            id: randomUUID(),
             sender: "agent",
             text: (msg.caption as string) ?? "",
             mediaUrl: msg.mediaUrl as string,
@@ -518,7 +519,7 @@ export default function App() {
         case "agent.a2ui": {
           if (!isCurrentSession(sessionKey)) break;
           const a2uiMsg: ChatMessage = {
-            id: crypto.randomUUID(),
+            id: randomUUID(),
             sender: "agent",
             text: "",
             a2ui: msg.jsonl as string,
@@ -677,7 +678,7 @@ export default function App() {
     const token = getToken();
     if (!token) return;
 
-    const sessionId = crypto.randomUUID();
+    const sessionId = randomUUID();
     dlog.info("WS", `Connecting WebSocket (session=${sessionId.slice(0, 8)}...)`);
     const client = new BotsChatWSClient({
       userId: state.user.id,

--- a/packages/web/src/components/ChatWindow.tsx
+++ b/packages/web/src/components/ChatWindow.tsx
@@ -5,6 +5,7 @@ import { MessageContent } from "./MessageContent";
 import { ModelSelect } from "./ModelSelect";
 import { SessionTabs } from "./SessionTabs";
 import { dlog } from "../debug-log";
+import { randomUUID } from "../utils/uuid";
 
 type ChatWindowProps = {
   sendMessage: (msg: WSMessage) => void;
@@ -229,7 +230,7 @@ export function ChatWindow({ sendMessage }: ChatWindowProps) {
     setSkillVersion((v) => v + 1);
 
     const msg: ChatMessage = {
-      id: crypto.randomUUID(),
+      id: randomUUID(),
       sender: "user",
       text: `/model ${modelId}`,
       timestamp: Date.now(),
@@ -381,7 +382,7 @@ export function ChatWindow({ sendMessage }: ChatWindowProps) {
     }
 
     const msg: ChatMessage = {
-      id: crypto.randomUUID(),
+      id: randomUUID(),
       sender: "user",
       text: trimmed,
       timestamp: Date.now(),
@@ -416,7 +417,7 @@ export function ChatWindow({ sendMessage }: ChatWindowProps) {
     if (!sessionKey) return;
     dlog.info("A2UI", `Action triggered: ${action}`);
     const msg: ChatMessage = {
-      id: crypto.randomUUID(),
+      id: randomUUID(),
       sender: "user",
       text: action,
       timestamp: Date.now(),
@@ -448,7 +449,7 @@ export function ChatWindow({ sendMessage }: ChatWindowProps) {
     // Send the chosen label as a user message (show the readable label, not the
     // technical value, so the chat history reads naturally)
     const msg: ChatMessage = {
-      id: crypto.randomUUID(),
+      id: randomUUID(),
       sender: "user",
       text: label,
       timestamp: Date.now(),
@@ -861,4 +862,3 @@ function ActionButton({
     </button>
   );
 }
-

--- a/packages/web/src/components/LoginPage.tsx
+++ b/packages/web/src/components/LoginPage.tsx
@@ -75,6 +75,9 @@ export function LoginPage() {
       }
       dlog.info("Auth", `${isRegister ? "Register" : "Login"} success — user ${res.id} (${res.email})`);
       handleAuthSuccess(res);
+      if (isRegister) {
+        localStorage.setItem("botschat_onboarding_dismissed", "1");
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : "Something went wrong";
       dlog.error("Auth", `${isRegister ? "Register" : "Login"} failed: ${message}`);

--- a/packages/web/src/components/ThreadPanel.tsx
+++ b/packages/web/src/components/ThreadPanel.tsx
@@ -4,6 +4,7 @@ import { messagesApi } from "../api";
 import type { WSMessage } from "../ws";
 import { MessageContent } from "./MessageContent";
 import { dlog } from "../debug-log";
+import { randomUUID } from "../utils/uuid";
 
 type ThreadPanelProps = {
   sendMessage: (msg: WSMessage) => void;
@@ -47,7 +48,7 @@ export function ThreadPanel({ sendMessage }: ThreadPanelProps) {
     dlog.info("Thread", `Send reply: ${trimmed.length > 120 ? trimmed.slice(0, 120) + "…" : trimmed}`, { threadId: state.activeThreadId });
 
     const msg: ChatMessage = {
-      id: crypto.randomUUID(),
+      id: randomUUID(),
       sender: "user",
       text: trimmed,
       timestamp: Date.now(),

--- a/packages/web/src/utils/uuid.ts
+++ b/packages/web/src/utils/uuid.ts
@@ -1,0 +1,21 @@
+/**
+ * Generate a UUID v4. Uses crypto.randomUUID() when available (HTTPS),
+ * otherwise falls back to crypto.getRandomValues() for HTTP/insecure contexts
+ * where randomUUID is not defined.
+ */
+export function randomUUID(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  // Fallback for insecure context (e.g. http://0.0.0.0:8787): UUID v4 via getRandomValues
+  const bytes = new Uint8Array(16);
+  if (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function") {
+    crypto.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < 16; i++) bytes[i] = Math.floor(Math.random() * 256);
+  }
+  bytes[6] = (bytes[6]! & 0x0f) | 0x40;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}


### PR DESCRIPTION
- Add API-side UUID helper with getRandomValues fallback
- Use UUID helper in upload route and ConnectionDO
- Use web UUID helper instead of crypto.randomUUID in UI
- After email signup, dismiss onboarding so app lands on main view

close https://github.com/botschat-app/botsChat/issues/1